### PR TITLE
edit basic example

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -50,6 +50,7 @@ library(rvest)
 
 session <- bow("https://www.cheese.com/by_type", force = TRUE)
 result <- scrape(session, params="t=semi-soft&per_page=100") %>%
+  html_node("#main-body") %>% 
   html_nodes("h3") %>% 
   html_text()
 head(result)


### PR DESCRIPTION
Currently, using "h3" to select cheese names also selects links in the bottom banner. `html_node("#main-body") %>%` limits the selection to the main body.


``` r
library(polite)
library(rvest)
#> Loading required package: xml2

session <- bow("https://www.cheese.com/by_type")
result <- scrape(session, params="t=semi-soft&per_page=100", accept = "html")

old <- result %>%
  html_nodes("h3") %>% 
  html_text()

new <- result %>%
  html_node("#main-body") %>% 
  html_nodes("h3") %>% 
  html_text()

length(old)
#> [1] 103
length(new)
#> [1] 100

head(old) == head(new)
#> [1] TRUE TRUE TRUE TRUE TRUE TRUE

tail(old)
#> [1] "Chaumes"            "Chevre"             "Chevre en Marinade"
#> [4] "Search"             "1831 cheese"        "Share!"
tail(new)
#> [1] "Celtic Promise"      "Chabichou du Poitou" "Charolais"          
#> [4] "Chaumes"             "Chevre"              "Chevre en Marinade"
```

Created on 2018-10-18 by the [reprex
package](http://reprex.tidyverse.org) (v0.2.0).