### PR TITLE
Add link to documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
-URL: https://github.com/dmi3kno/polite
+URL: https://github.com/dmi3kno/polite, https://dmi3kno.github.io/polite/
 BugReports: https://github.com/dmi3kno/polite/issues
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0


### PR DESCRIPTION
So the website can be accessed directly from the CRAN page. This is also used by pkgdown to cross-link: https://pkgdown.r-lib.org/articles/linking.html