### PR TITLE
create directory if necessary

### DIFF
--- a/R/use-manners.R
+++ b/R/use-manners.R
@@ -8,6 +8,10 @@
 #' @export
 use_manners <- function(save_as="R/polite-scrape.R", open = TRUE) {
 
+  save_as_directory = dirname(save_as)
+  if (! dir.exists(save_as_directory)) {
+    dir.create(save_as_directory)
+  }
   usethis::use_template("polite_template.R", save_as = save_as,
                       open = open, package = "polite")
   invisible()

--- a/R/use-manners.R
+++ b/R/use-manners.R
@@ -8,7 +8,7 @@
 #' @export
 use_manners <- function(save_as="R/polite-scrape.R", open = TRUE) {
 
-  save_as_directory = dirname(save_as)
+  save_as_directory <- dirname(save_as)
   if (! dir.exists(save_as_directory)) {
     dir.create(save_as_directory)
   }


### PR DESCRIPTION
The README for `use_manners()` [claims ](https://github.com/dmi3kno/polite/blob/develop/README.Rmd#L163) that it will create the R directory if necessary, but instead `use_manners()` fails if the R directory doesn't exist. This PR fixes that behavior; it checks for existence of the directory and creates it if necessary.

## Current behavior
```r
> dir.exists("R")
[1] FALSE
> polite::use_manners()
✔ Writing 'R/polite-scrape.R'
Error in file(path, open = file_mode, encoding = "utf-8") : 
  cannot open the connection
In addition: Warning message:
In file(path, open = file_mode, encoding = "utf-8") :
  cannot open file '/home/jross/cdi-code-releases/R/polite-scrape.R': No such file or directory
```

## Behavior in this fix
```r
> dir.exists("R")
[1] FALSE
> polite::use_manners()
✔ Writing 'R/polite-scrape.R'
• Modify 'R/polite-scrape.R'
> dir.exists("R")
[1] TRUE
> dir.exists("foo")
[1] FALSE
> polite::use_manners(save_as = "foo/polite-scrape.R")
✔ Writing 'foo/polite-scrape.R'
• Modify 'foo/polite-scrape.R'
> dir.exists("foo")
[1] TRUE
```